### PR TITLE
more test cases, handle string literals

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 'use strict';
 module.exports = function (val) {
-	return val != null && 'function' === typeof val[Symbol.iterator];
+	return (Symbol && Symbol.iterator
+		&& val != null && 'function' === typeof val[Symbol.iterator]);
 };

--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 'use strict';
 module.exports = function (val) {
-	return (val !== null && typeof val === 'object'
-		&& typeof val[Symbol.iterator] === 'function');
+	return val != null && 'function' === typeof val[Symbol.iterator];
 };

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 'use strict';
 module.exports = function (val) {
-	return (Symbol && Symbol.iterator
+	return (Symbol && 'iterator' in Symbol
 		&& val != null && 'function' === typeof val[Symbol.iterator]);
 };

--- a/test.js
+++ b/test.js
@@ -2,11 +2,38 @@
 var assert = require('assert');
 var isIterable = require('./');
 
-it('should detected non iterable values', function () {
-	assert.strictEqual(!isIterable({}), true);
+it('should detected non-iterable values', function () {
+	assert.strictEqual(isIterable({}), false);
+	assert.strictEqual(isIterable(new Object()), false);
+
+	assert.strictEqual(isIterable(true), false);
+	assert.strictEqual(isIterable(new Boolean(true)), false);
+
+	assert.strictEqual(isIterable(1), false);
+	assert.strictEqual(isIterable(new Number(1)), false);
+	assert.strictEqual(isIterable(Infinity), false);
+
+	assert.strictEqual(isIterable(function(){}), false);
+	assert.strictEqual(isIterable(new Function('')), false);
+
+	assert.strictEqual(isIterable(new RegExp('/./i')), false);
+	assert.strictEqual(isIterable(/./i), false);
+
+	assert.strictEqual(isIterable(undefined), false);
+	assert.strictEqual(isIterable(null), false);
+	assert.strictEqual(isIterable(NaN), false);
+
+	assert.strictEqual(isIterable(new WeakSet()), false);
+	assert.strictEqual(isIterable(new WeakMap()), false);
 });
 
 it('should detect iterable values', function() {
-	var arr = [1,2,3];
-	assert.strictEqual(isIterable(arr[Symbol.iterator]()),true);
+	assert.strictEqual(isIterable(new String('foo')), true);
+
+	assert.strictEqual(isIterable([1,2,3]), true);
+	assert.strictEqual(isIterable([1,2,3][Symbol.iterator]()), true);
+	assert.strictEqual(isIterable(new Array([1,2,3])), true);
+
+	assert.strictEqual(isIterable(new Map()), true);
+	assert.strictEqual(isIterable(new Set()), true);
 });

--- a/test.js
+++ b/test.js
@@ -29,6 +29,7 @@ it('should detected non-iterable values', function () {
 
 it('should detect iterable values', function() {
 	assert.strictEqual(isIterable(new String('foo')), true);
+	assert.strictEqual(isIterable('foo'), true);
 
 	assert.strictEqual(isIterable([1,2,3]), true);
 	assert.strictEqual(isIterable([1,2,3][Symbol.iterator]()), true);


### PR DESCRIPTION
af3cb8a adds more test cases to make future changes safer.

ffac5b0 changes `is-generator` to properly detect string literals (`'foo'`) as iterables.
- `typeof val !== 'object'` rejected them, only `String` objects (`new String('foo')`) passed.
- `val != null` is more robust (taken from CoffeeScript).
- Putting `typeof …` behind `===` makes the expression easier to read.
